### PR TITLE
Specify `predicate_type` when fetching attestation

### DIFF
--- a/src/Verification/VerifyAttestationWithOpenSsl.php
+++ b/src/Verification/VerifyAttestationWithOpenSsl.php
@@ -322,7 +322,7 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
     private function downloadAttestations(FilenameWithChecksum $file, string $owner): array
     {
         $attestationUrl = sprintf(
-            '%s/orgs/%s/attestations/sha256:%s',
+            '%s/orgs/%s/attestations/sha256:%s?predicate_type=provenance',
             $this->githubApiBaseUrl,
             $owner,
             $file->checksum(),


### PR DESCRIPTION
Refers to php/pie#439

Since immutable releases were added, attestations returned can be different types; this library (at least for now) is only interested in build provenance (other types can be added later, of course!)