### PR TITLE
Setup `.gitattributes` - in order to exclude test dir from dist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+*.php text eol=lf
+*.phpt text eol=lf
+/.editorconfig export-ignore
+/.gitattributes export-ignore
+/.github/ export-ignore
+/.gitignore export-ignore
+/composer.lock export-ignore
+/phpcs.xml.dist export-ignore
+/phpstan.neon export-ignore
+/phpunit.xml.dist export-ignore
+/test/ export-ignore


### PR DESCRIPTION
I noticed pie.phar includes attestation's test directory. I belive this is not necessary for distributions.

```bash
php -r 'foreach(new RecursiveIteratorIterator(new Phar($argv[1])) as $f)echo $f."\n";' pie-nightly.phar | cut -d/ -f9- | grep attestation | grep test/
pie-nightly.phar/vendor/thephpf/attestation/test/fixture/pie-with-attestation-for-different-owner.phar
pie-nightly.phar/vendor/thephpf/attestation/test/integration/Verification/VerifyAttestationWithOpenSslTest.php
pie-nightly.phar/vendor/thephpf/attestation/test/unit/FilenameWithChecksumTest.php
```

* `.gitattributes` is mostly taken from BetterReflection
https://github.com/Roave/BetterReflection/blob/6.67.x/.gitattributes

* With this PR, The archive targets other than `src/` will be as follows:

```
git archive --format=tar HEAD | tar -tf - | grep -v src/
LICENSE.md
README.md
composer.json
resources/
resources/trusted-root.jsonl
```