### PR TITLE
Introduce PemCertificate and DsseEnvelope objects

### DIFF
--- a/src/Attestation.php
+++ b/src/Attestation.php
@@ -6,7 +6,6 @@ namespace ThePhpFoundation\Attestation;
 
 use Webmozart\Assert\Assert;
 
-use function base64_decode;
 use function wordwrap;
 
 /** @internal This is not a public API, so should not be depended upon unless you accept the risk of BC breaks */
@@ -14,29 +13,13 @@ final class Attestation
 {
     /** @var non-empty-string */
     public string $certificate;
-    /** @var non-empty-string */
-    public string $dsseEnvelopePayload;
-    /** @var non-empty-string */
-    public string $dsseEnvelopePayloadType;
-    /** @var non-empty-string */
-    public string $dsseEnvelopeSignature;
+    public DsseEnvelope $dsseEnvelope;
 
-    /**
-     * @param non-empty-string $certificate
-     * @param non-empty-string $dsseEnvelopePayload
-     * @param non-empty-string $dsseEnvelopePayloadType
-     * @param non-empty-string $dsseEnvelopeSignature
-     */
-    private function __construct(
-        string $certificate,
-        string $dsseEnvelopePayload,
-        string $dsseEnvelopePayloadType,
-        string $dsseEnvelopeSignature
-    ) {
-        $this->dsseEnvelopeSignature   = $dsseEnvelopeSignature;
-        $this->dsseEnvelopePayloadType = $dsseEnvelopePayloadType;
-        $this->dsseEnvelopePayload     = $dsseEnvelopePayload;
-        $this->certificate             = $certificate;
+    /** @param non-empty-string $certificate */
+    private function __construct(string $certificate, DsseEnvelope $dsseEnvelope)
+    {
+        $this->certificate  = $certificate;
+        $this->dsseEnvelope = $dsseEnvelope;
     }
 
     /** @param array<array-key, mixed> $bundle */
@@ -51,33 +34,14 @@ final class Attestation
 
         Assert::keyExists($bundle, 'dsseEnvelope');
         Assert::isArray($bundle['dsseEnvelope']);
-        Assert::keyExists($bundle['dsseEnvelope'], 'payload');
-        Assert::stringNotEmpty($bundle['dsseEnvelope']['payload']);
-        Assert::keyExists($bundle['dsseEnvelope'], 'payloadType');
-        Assert::stringNotEmpty($bundle['dsseEnvelope']['payloadType']);
-        Assert::keyExists($bundle['dsseEnvelope'], 'signatures');
-        Assert::isNonEmptyList($bundle['dsseEnvelope']['signatures']);
-        Assert::count($bundle['dsseEnvelope']['signatures'], 1);
-        Assert::keyExists($bundle['dsseEnvelope']['signatures'], 0);
-        Assert::isArray($bundle['dsseEnvelope']['signatures'][0]);
-        Assert::keyExists($bundle['dsseEnvelope']['signatures'][0], 'sig');
-        Assert::stringNotEmpty($bundle['dsseEnvelope']['signatures'][0]['sig']);
 
         $decoratedCertificate = "-----BEGIN CERTIFICATE-----\n"
             . wordwrap($bundle['verificationMaterial']['certificate']['rawBytes'], 67, "\n", true) . "\n"
             . "-----END CERTIFICATE-----\n";
 
-        $decodedPayload = base64_decode($bundle['dsseEnvelope']['payload']);
-        Assert::stringNotEmpty($decodedPayload);
-
-        $decodedSignature = base64_decode($bundle['dsseEnvelope']['signatures'][0]['sig']);
-        Assert::stringNotEmpty($decodedSignature);
-
         return new self(
             $decoratedCertificate,
-            $decodedPayload,
-            $bundle['dsseEnvelope']['payloadType'],
-            $decodedSignature,
+            DsseEnvelope::fromBundleDsseEnvelope($bundle['dsseEnvelope']),
         );
     }
 }

--- a/src/Attestation.php
+++ b/src/Attestation.php
@@ -6,17 +6,13 @@ namespace ThePhpFoundation\Attestation;
 
 use Webmozart\Assert\Assert;
 
-use function wordwrap;
-
 /** @internal This is not a public API, so should not be depended upon unless you accept the risk of BC breaks */
 final class Attestation
 {
-    /** @var non-empty-string */
-    public string $certificate;
+    public PemCertificate $certificate;
     public DsseEnvelope $dsseEnvelope;
 
-    /** @param non-empty-string $certificate */
-    private function __construct(string $certificate, DsseEnvelope $dsseEnvelope)
+    private function __construct(PemCertificate $certificate, DsseEnvelope $dsseEnvelope)
     {
         $this->certificate  = $certificate;
         $this->dsseEnvelope = $dsseEnvelope;
@@ -35,12 +31,8 @@ final class Attestation
         Assert::keyExists($bundle, 'dsseEnvelope');
         Assert::isArray($bundle['dsseEnvelope']);
 
-        $decoratedCertificate = "-----BEGIN CERTIFICATE-----\n"
-            . wordwrap($bundle['verificationMaterial']['certificate']['rawBytes'], 67, "\n", true) . "\n"
-            . "-----END CERTIFICATE-----\n";
-
         return new self(
-            $decoratedCertificate,
+            PemCertificate::fromBase64EncodedDerBytes($bundle['verificationMaterial']['certificate']['rawBytes']),
             DsseEnvelope::fromBundleDsseEnvelope($bundle['dsseEnvelope']),
         );
     }

--- a/src/DsseEnvelope.php
+++ b/src/DsseEnvelope.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThePhpFoundation\Attestation;
+
+use Webmozart\Assert\Assert;
+
+use function base64_decode;
+use function sprintf;
+use function strlen;
+
+/** @internal This is not a public API, so should not be depended upon unless you accept the risk of BC breaks */
+final class DsseEnvelope
+{
+    /** @var non-empty-string */
+    public string $payload;
+    /** @var non-empty-string */
+    public string $payloadType;
+    /** @var non-empty-string */
+    public string $signature;
+
+    /**
+     * @param non-empty-string $payload
+     * @param non-empty-string $payloadType
+     * @param non-empty-string $signature
+     */
+    private function __construct(string $payload, string $payloadType, string $signature)
+    {
+        $this->payload     = $payload;
+        $this->payloadType = $payloadType;
+        $this->signature   = $signature;
+    }
+
+    /** @param array<array-key, mixed> $dsseEnvelope */
+    public static function fromBundleDsseEnvelope(array $dsseEnvelope): self
+    {
+        Assert::keyExists($dsseEnvelope, 'payload');
+        Assert::stringNotEmpty($dsseEnvelope['payload']);
+        Assert::keyExists($dsseEnvelope, 'payloadType');
+        Assert::stringNotEmpty($dsseEnvelope['payloadType']);
+        Assert::keyExists($dsseEnvelope, 'signatures');
+        Assert::isNonEmptyList($dsseEnvelope['signatures']);
+        Assert::count($dsseEnvelope['signatures'], 1);
+        Assert::isArray($dsseEnvelope['signatures'][0]);
+        Assert::keyExists($dsseEnvelope['signatures'][0], 'sig');
+        Assert::stringNotEmpty($dsseEnvelope['signatures'][0]['sig']);
+
+        $decodedPayload = base64_decode($dsseEnvelope['payload']);
+        Assert::stringNotEmpty($decodedPayload);
+
+        $decodedSignature = base64_decode($dsseEnvelope['signatures'][0]['sig']);
+        Assert::stringNotEmpty($decodedSignature);
+
+        return new self(
+            $decodedPayload,
+            $dsseEnvelope['payloadType'],
+            $decodedSignature,
+        );
+    }
+
+    /**
+     * The Pre-Authentication Encoding is what the DSSE signature is actually calculated over.
+     *
+     * @link https://github.com/secure-systems-lab/dsse/blob/master/protocol.md#protocol
+     *
+     * @return non-empty-string
+     */
+    public function preAuthenticationEncoding(): string
+    {
+        return sprintf(
+            'DSSEv1 %d %s %d %s',
+            strlen($this->payloadType),
+            $this->payloadType,
+            strlen($this->payload),
+            $this->payload,
+        );
+    }
+}

--- a/src/PemCertificate.php
+++ b/src/PemCertificate.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ThePhpFoundation\Attestation;
+
+use function wordwrap;
+
+/**
+ * A certificate in the shape Sigstore bundles and trusted roots carry it, i.e. base64-encoded DER.
+ *
+ * @internal This is not a public API, so should not be depended upon unless you accept the risk of BC breaks
+ */
+final class PemCertificate
+{
+    /** @var non-empty-string */
+    private string $base64EncodedDerBytes;
+
+    /** @param non-empty-string $base64EncodedDerBytes */
+    private function __construct(string $base64EncodedDerBytes)
+    {
+        $this->base64EncodedDerBytes = $base64EncodedDerBytes;
+    }
+
+    /** @param non-empty-string $base64EncodedDerBytes */
+    public static function fromBase64EncodedDerBytes(string $base64EncodedDerBytes): self
+    {
+        return new self($base64EncodedDerBytes);
+    }
+
+    /**
+     * OpenSSL will not take the base64-encoded DER on its own; it wants it wrapped in a PEM envelope.
+     *
+     * @return non-empty-string
+     */
+    public function decoratedCertificate(): string
+    {
+        return "-----BEGIN CERTIFICATE-----\n"
+            . wordwrap($this->base64EncodedDerBytes, 67, "\n", true) . "\n"
+            . "-----END CERTIFICATE-----\n";
+    }
+}

--- a/src/Verification/VerifyAttestationWithOpenSsl.php
+++ b/src/Verification/VerifyAttestationWithOpenSsl.php
@@ -282,15 +282,14 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
         $publicKey = openssl_pkey_get_public($attestation->certificate);
         Assert::notFalse($publicKey);
 
-        $preAuthenticationEncoding = sprintf(
-            'DSSEv1 %d %s %d %s',
-            strlen($attestation->dsseEnvelopePayloadType),
-            $attestation->dsseEnvelopePayloadType,
-            strlen($attestation->dsseEnvelopePayload),
-            $attestation->dsseEnvelopePayload,
-        );
-
-        if (openssl_verify($preAuthenticationEncoding, $attestation->dsseEnvelopeSignature, $publicKey, OPENSSL_ALGO_SHA256) !== 1) {
+        if (
+            openssl_verify(
+                $attestation->dsseEnvelope->preAuthenticationEncoding(),
+                $attestation->dsseEnvelope->signature,
+                $publicKey,
+                OPENSSL_ALGO_SHA256,
+            ) !== 1
+        ) {
             throw SignatureVerificationFailed::forIndex($attestationIndex);
         }
     }
@@ -299,7 +298,7 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
     private function assertDigestFromAttestationMatchesActual(FilenameWithChecksum $file, string $expectedSubjectName, Attestation $attestation): void
     {
         /** @var mixed $decodedPayload */
-        $decodedPayload = json_decode($attestation->dsseEnvelopePayload, true);
+        $decodedPayload = json_decode($attestation->dsseEnvelope->payload, true);
 
         if (
             ! is_array($decodedPayload)

--- a/src/Verification/VerifyAttestationWithOpenSsl.php
+++ b/src/Verification/VerifyAttestationWithOpenSsl.php
@@ -10,6 +10,7 @@ use Composer\IO\NullIO;
 use Composer\Util\HttpDownloader;
 use ThePhpFoundation\Attestation\Attestation;
 use ThePhpFoundation\Attestation\FilenameWithChecksum;
+use ThePhpFoundation\Attestation\PemCertificate;
 use ThePhpFoundation\Attestation\Verification\Exception\DigestMismatch;
 use ThePhpFoundation\Attestation\Verification\Exception\FailedToFetchBundleUrl;
 use ThePhpFoundation\Attestation\Verification\Exception\InvalidDerEncodedStringLength;
@@ -42,7 +43,6 @@ use function sprintf;
 use function strlen;
 use function substr;
 use function trim;
-use function wordwrap;
 
 use const OPENSSL_ALGO_SHA256;
 
@@ -129,7 +129,7 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
 
     private function assertCertificateSignedByTrustedRoot(Attestation $attestation): void
     {
-        $attestationCertificateInfo = openssl_x509_parse($attestation->certificate);
+        $attestationCertificateInfo = openssl_x509_parse($attestation->certificate->decoratedCertificate());
         Assert::isArray($attestationCertificateInfo);
         Assert::keyExists($attestationCertificateInfo, 'issuer');
         if (is_array($attestationCertificateInfo['issuer'])) {
@@ -190,15 +190,9 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
                         continue;
                     }
 
-                    // Embed the base64-encoded DER into a PEM envelope for consumption by OpenSSL.
-                    $caCertificateString = sprintf(
-                        <<<'EOT'
-                        -----BEGIN CERTIFICATE-----
-                        %s
-                        -----END CERTIFICATE-----
-                        EOT,
-                        wordwrap($caCertificateWrapper['rawBytes'], 67, "\n", true),
-                    );
+                    $caCertificateString = PemCertificate::fromBase64EncodedDerBytes(
+                        $caCertificateWrapper['rawBytes'],
+                    )->decoratedCertificate();
 
                     $caCertificateInfo = openssl_x509_parse($caCertificateString);
                     Assert::isArray($caCertificateInfo);
@@ -211,7 +205,7 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
                     }
 
                     // Finally, verify that the located CA cert was used to sign the attestation certificate
-                    if (openssl_x509_verify($attestation->certificate, $caCertificateString) !== 1) {
+                    if (openssl_x509_verify($attestation->certificate->decoratedCertificate(), $caCertificateString) !== 1) {
                         /** @psalm-suppress MixedArgument */
                         throw IssuerCertificateVerificationFailed::fromIssuer($attestationCertificateInfo['issuer']);
                     }
@@ -233,7 +227,7 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
     /** @param array<non-empty-string, string> $extensions */
     private function assertCertificateExtensionClaims(Attestation $attestation, array $extensions): void
     {
-        $attestationCertificateInfo = openssl_x509_parse($attestation->certificate);
+        $attestationCertificateInfo = openssl_x509_parse($attestation->certificate->decoratedCertificate());
         Assert::isArray($attestationCertificateInfo);
         Assert::keyExists($attestationCertificateInfo, 'extensions');
         Assert::isArray($attestationCertificateInfo['extensions']);
@@ -279,7 +273,7 @@ class VerifyAttestationWithOpenSsl implements VerifyAttestation
             throw NoOpenssl::new();
         }
 
-        $publicKey = openssl_pkey_get_public($attestation->certificate);
+        $publicKey = openssl_pkey_get_public($attestation->certificate->decoratedCertificate());
         Assert::notFalse($publicKey);
 
         if (


### PR DESCRIPTION
The [sigstore conformance test suite](https://github.com/ThePHPF/attestation/issues/21) mainly runs based on sigstore bundles and not attestations. Extracting individual parts of the attestation into their own classes to make the transition to sigstore bundles easier.